### PR TITLE
feat(types): improve `Ordered` type

### DIFF
--- a/snapshots/ramda-tests.ts
+++ b/snapshots/ramda-tests.ts
@@ -312,11 +312,23 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass -> 1 | 10 | -1
   R.clamp(1, 10, -1); //=> 1
   // @dts-jest:pass -> number
-  R.clamp<number>(1, 10)(11); //=> 10
+  R.clamp(1)(10)(-1); //=> 1
   // @dts-jest:pass -> number
-  R.clamp<number>(1)(10, 4); //=> 4
+  R.clamp(1, 10)(11); //=> 10
+  // @dts-jest:pass -> number
+  R.clamp(1)(10, 4); //=> 4
   // @dts-jest:pass -> "a" | "d" | "e"
   R.clamp('a', 'd', 'e'); //=> 'd'
+  // @dts-jest:pass -> string
+  R.clamp('a')('d')('e'); //=> 'd'
+  // @dts-jest:fail -> Argument of type '"str"' is not assignable to parameter of type '1'.
+  R.clamp(1, 'str', true);
+  // @dts-jest:fail -> Argument of type '"str"' is not assignable to parameter of type 'number'.
+  R.clamp(1)('str')(true);
+  // @dts-jest:pass -> Date
+  R.clamp(new Date(0), new Date(1), new Date(2)); //=> new Date(1)
+  // @dts-jest:pass -> Date
+  R.clamp(new Date(0))(new Date(1))(new Date(2)); //=> new Date(1)
 })();
 
 // @dts-jest:group clone
@@ -413,7 +425,7 @@ import * as R from '../ramda/dist/index';
 
     // akward example that bounces types between number and string
     const g0 = (list: number[]) => R.map(R.inc, list);
-    const g1 = R.dropWhile(R.gt<number>(10));
+    const g1 = R.dropWhile(R.gt(10));
     const g2 = R.map((i: number) => i > 5 ? 'bigger' : 'smaller');
     const g3 = R.all((i: string) => i === 'smaller');
     const g = R.compose<number[], number[], number[], string[], boolean>(g3, g2, g1, g0);
@@ -984,7 +996,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass -> boolean
   R.flip(R.gt<'11'>())(2)(10); //=> true
   // @dts-jest:pass -> boolean
-  R.gt<number>(2)(10); //=> false
+  R.gt(2)(10); //=> false
 })();
 
 // @dts-jest:group gte
@@ -998,7 +1010,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass -> boolean
   R.flip(R.gte<'11'>())(2)(10); //=> true
   // @dts-jest:pass -> boolean
-  R.gte<number>(2)(10); //=> false
+  R.gte(2)(10); //=> false
 })();
 
 // @dts-jest:group has
@@ -1504,7 +1516,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass -> boolean
   R.lt(2, 2); //=> false
   // @dts-jest:pass -> boolean
-  R.lt<number>(5)(10); //=> true
+  R.lt(5)(10); //=> true
   // @dts-jest:pass -> boolean
   R.flip(R.lt<'11'>())(5)(10); //=> false
 })();
@@ -1518,7 +1530,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass -> boolean
   R.lte(2, 2); //=> true
   // @dts-jest:pass -> boolean
-  R.lte<number>(2)(10); //=> true
+  R.lte(2)(10); //=> true
   // @dts-jest:pass -> boolean
   R.flip(R.lte<'11'>())(2)(1); //=> true
 })();

--- a/templates/$types.d.ts
+++ b/templates/$types.d.ts
@@ -1,6 +1,5 @@
 // simple
 
-export type Ordered = string | number | boolean | Date;
 export type Property = string | number | symbol;
 export type Path = List<Property>;
 
@@ -39,6 +38,10 @@ export interface Dictionary<T> {
 }
 export interface NestedDictionary<T> {
   [key: string]: T | NestedDictionary<T>;
+}
+
+export interface Ordered {
+  valueOf(): string | number | boolean;
 }
 
 // ramda

--- a/templates/ascend.d.ts
+++ b/templates/ascend.d.ts
@@ -1,3 +1,3 @@
 import {Morphism, Ordered} from './$types';
 
-export function $<T, U extends Ordered>(fn: Morphism<T, U>, a: T, b: T): number;
+export function $<T>(fn: Morphism<T, Ordered>, a: T, b: T): number;

--- a/templates/descend.d.ts
+++ b/templates/descend.d.ts
@@ -1,3 +1,3 @@
 import {Morphism, Ordered} from './$types';
 
-export function $<T, U extends Ordered>(fn: Morphism<T, U>, a: T, b: T): number;
+export function $<T>(fn: Morphism<T, Ordered>, a: T, b: T): number;

--- a/tests/__snapshots__/ramda-tests.ts.snap
+++ b/tests/__snapshots__/ramda-tests.ts.snap
@@ -132,13 +132,25 @@ exports[`chain R.chain<number, number[], number | undefined>(R.append)(R.head)([
 
 exports[`chain R.chain<number, number[], number | undefined>(R.append, R.head)([1, 2, 3]) 1`] = `"number[]"`;
 
+exports[`clamp R.clamp('a')('d')('e') 1`] = `"string"`;
+
 exports[`clamp R.clamp('a', 'd', 'e') 1`] = `"\\"a\\" | \\"d\\" | \\"e\\""`;
+
+exports[`clamp R.clamp(1)('str')(true) 1`] = `"Argument of type '\\"str\\"' is not assignable to parameter of type 'number'."`;
+
+exports[`clamp R.clamp(1)(10)(-1) 1`] = `"number"`;
+
+exports[`clamp R.clamp(1)(10, 4) 1`] = `"number"`;
+
+exports[`clamp R.clamp(1, 'str', true) 1`] = `"Argument of type '\\"str\\"' is not assignable to parameter of type '1'."`;
+
+exports[`clamp R.clamp(1, 10)(11) 1`] = `"number"`;
 
 exports[`clamp R.clamp(1, 10, -1) 1`] = `"1 | 10 | -1"`;
 
-exports[`clamp R.clamp<number>(1)(10, 4) 1`] = `"number"`;
+exports[`clamp R.clamp(new Date(0))(new Date(1))(new Date(2)) 1`] = `"Date"`;
 
-exports[`clamp R.clamp<number>(1, 10)(11) 1`] = `"number"`;
+exports[`clamp R.clamp(new Date(0), new Date(1), new Date(2)) 1`] = `"Date"`;
 
 exports[`clone R.clone('foo') 1`] = `"\\"foo\\""`;
 

--- a/tests/__snapshots__/ramda-tests.ts.snap
+++ b/tests/__snapshots__/ramda-tests.ts.snap
@@ -420,23 +420,23 @@ exports[`groupWith R.groupWith(R.equals, [0, 1, 1, 2, 3, 5, 8, 13, 21]) 1`] = `"
 
 exports[`gt R.flip(R.gt<'11'>())(2)(10) 1`] = `"boolean"`;
 
+exports[`gt R.gt(2)(10) 1`] = `"boolean"`;
+
 exports[`gt R.gt(2, 0) 1`] = `"boolean"`;
 
 exports[`gt R.gt(2, 2) 1`] = `"boolean"`;
 
 exports[`gt R.gt(2, 6) 1`] = `"boolean"`;
 
-exports[`gt R.gt<number>(2)(10) 1`] = `"boolean"`;
-
 exports[`gte R.flip(R.gte<'11'>())(2)(10) 1`] = `"boolean"`;
+
+exports[`gte R.gte(2)(10) 1`] = `"boolean"`;
 
 exports[`gte R.gte(2, 0) 1`] = `"boolean"`;
 
 exports[`gte R.gte(2, 2) 1`] = `"boolean"`;
 
 exports[`gte R.gte(2, 6) 1`] = `"boolean"`;
-
-exports[`gte R.gte<number>(2)(10) 1`] = `"boolean"`;
 
 exports[`has hasName({}) 1`] = `"boolean"`;
 
@@ -698,17 +698,17 @@ exports[`lt R.lt(2, 2) 1`] = `"boolean"`;
 
 exports[`lt R.lt(2, 6) 1`] = `"boolean"`;
 
-exports[`lt R.lt<number>(5)(10) 1`] = `"boolean"`;
+exports[`lt R.lt(5)(10) 1`] = `"boolean"`;
 
 exports[`lte R.flip(R.lte<'11'>())(2)(1) 1`] = `"boolean"`;
+
+exports[`lte R.lte(2)(10) 1`] = `"boolean"`;
 
 exports[`lte R.lte(2, 0) 1`] = `"boolean"`;
 
 exports[`lte R.lte(2, 2) 1`] = `"boolean"`;
 
 exports[`lte R.lte(2, 6) 1`] = `"boolean"`;
-
-exports[`lte R.lte<number>(2)(10) 1`] = `"boolean"`;
 
 exports[`map R.map(double)([1, 2, 3]) 1`] = `"number[]"`;
 

--- a/tests/ramda-tests.ts
+++ b/tests/ramda-tests.ts
@@ -312,11 +312,23 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass
   R.clamp(1, 10, -1); //=> 1
   // @dts-jest:pass
-  R.clamp<number>(1, 10)(11); //=> 10
+  R.clamp(1)(10)(-1); //=> 1
   // @dts-jest:pass
-  R.clamp<number>(1)(10, 4); //=> 4
+  R.clamp(1, 10)(11); //=> 10
+  // @dts-jest:pass
+  R.clamp(1)(10, 4); //=> 4
   // @dts-jest:pass
   R.clamp('a', 'd', 'e'); //=> 'd'
+  // @dts-jest:pass
+  R.clamp('a')('d')('e'); //=> 'd'
+  // @dts-jest:fail
+  R.clamp(1, 'str', true);
+  // @dts-jest:fail
+  R.clamp(1)('str')(true);
+  // @dts-jest:pass
+  R.clamp(new Date(0), new Date(1), new Date(2)); //=> new Date(1)
+  // @dts-jest:pass
+  R.clamp(new Date(0))(new Date(1))(new Date(2)); //=> new Date(1)
 })();
 
 // @dts-jest:group clone

--- a/tests/ramda-tests.ts
+++ b/tests/ramda-tests.ts
@@ -425,7 +425,7 @@ import * as R from '../ramda/dist/index';
 
     // akward example that bounces types between number and string
     const g0 = (list: number[]) => R.map(R.inc, list);
-    const g1 = R.dropWhile(R.gt<number>(10));
+    const g1 = R.dropWhile(R.gt(10));
     const g2 = R.map((i: number) => i > 5 ? 'bigger' : 'smaller');
     const g3 = R.all((i: string) => i === 'smaller');
     const g = R.compose<number[], number[], number[], string[], boolean>(g3, g2, g1, g0);
@@ -996,7 +996,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass
   R.flip(R.gt<'11'>())(2)(10); //=> true
   // @dts-jest:pass
-  R.gt<number>(2)(10); //=> false
+  R.gt(2)(10); //=> false
 })();
 
 // @dts-jest:group gte
@@ -1010,7 +1010,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass
   R.flip(R.gte<'11'>())(2)(10); //=> true
   // @dts-jest:pass
-  R.gte<number>(2)(10); //=> false
+  R.gte(2)(10); //=> false
 })();
 
 // @dts-jest:group has
@@ -1516,7 +1516,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass
   R.lt(2, 2); //=> false
   // @dts-jest:pass
-  R.lt<number>(5)(10); //=> true
+  R.lt(5)(10); //=> true
   // @dts-jest:pass
   R.flip(R.lt<'11'>())(5)(10); //=> false
 })();
@@ -1530,7 +1530,7 @@ import * as R from '../ramda/dist/index';
   // @dts-jest:pass
   R.lte(2, 2); //=> true
   // @dts-jest:pass
-  R.lte<number>(2)(10); //=> true
+  R.lte(2)(10); //=> true
   // @dts-jest:pass
   R.flip(R.lte<'11'>())(2)(1); //=> true
 })();


### PR DESCRIPTION
This PR improves the `Ordered` type, so that inferences for `R.clamp`, `R.gt`, etc. will not be too strict.

```diff
R.clamp(1, 2, 3) //=> 1 | 2 | 3

-R.clamp(1)(2)(3) //=> 2 is not assignable to type 1
+R.clamp(1)(2)(3) //=> number
```